### PR TITLE
Separate settings menu and legend

### DIFF
--- a/TTC/index.html
+++ b/TTC/index.html
@@ -36,40 +36,42 @@
         <li>Loading zones...</li>
       </ul>
 
-      <h3>Legend</h3>
-      <div style="margin-bottom: 1rem;">
-        <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-          <span
-            style="display:inline-block;width:24px;height:6px;background:#F8C300;opacity:0.4;margin-right:8px;"></span>
-          <span>Line 1 (Regular)</span>
-        </div>
-        <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-          <span style="display:inline-block;width:24px;height:6px;background:#F8C300;margin-right:8px;"></span>
-          <span>Line 1 (Reduced Speed Zone)</span>
-        </div>
-        <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-          <span
-            style="display:inline-block;width:24px;height:6px;background:#00923F;opacity:0.4;margin-right:8px;"></span>
-          <span>Line 2 (Regular)</span>
-        </div>
-        <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-          <span style="display:inline-block;width:24px;height:6px;background:#00923F;margin-right:8px;"></span>
-          <span>Line 2 (Reduced Speed Zone)</span>
-        </div>
-        <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-          <span
-            style="display:inline-block;width:24px;height:6px;background:#A21A68;opacity:0.4;margin-right:8px;"></span>
-          <span>Line 4 (Regular)</span>
-        </div>
-        <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-          <span style="display:inline-block;width:24px;height:6px;background:#A21A68;margin-right:8px;"></span>
-          <span>Line 4 (Reduced Speed Zone)</span>
-        </div>
-      </div>
     </aside>
 
     <div id="map-container">
       <div id="map"></div>
+      <div id="legend">
+        <h3>Legend</h3>
+        <div style="margin-bottom: 1rem;">
+          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
+            <span
+              style="display:inline-block;width:24px;height:6px;background:#F8C300;opacity:0.4;margin-right:8px;"></span>
+            <span>Line 1 (Regular)</span>
+          </div>
+          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
+            <span style="display:inline-block;width:24px;height:6px;background:#F8C300;margin-right:8px;"></span>
+            <span>Line 1 (Reduced Speed Zone)</span>
+          </div>
+          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
+            <span
+              style="display:inline-block;width:24px;height:6px;background:#00923F;opacity:0.4;margin-right:8px;"></span>
+            <span>Line 2 (Regular)</span>
+          </div>
+          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
+            <span style="display:inline-block;width:24px;height:6px;background:#00923F;margin-right:8px;"></span>
+            <span>Line 2 (Reduced Speed Zone)</span>
+          </div>
+          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
+            <span
+              style="display:inline-block;width:24px;height:6px;background:#A21A68;opacity:0.4;margin-right:8px;"></span>
+            <span>Line 4 (Regular)</span>
+          </div>
+          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
+            <span style="display:inline-block;width:24px;height:6px;background:#A21A68;margin-right:8px;"></span>
+            <span>Line 4 (Reduced Speed Zone)</span>
+          </div>
+        </div>
+      </div>
     </div>
   </main>
 

--- a/TTC/style.css
+++ b/TTC/style.css
@@ -63,6 +63,10 @@ main {
 }
 
 aside {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
   width: var(--sidebar-width);
   background-color: var(--aside-bg);
   padding: var(--sidebar-padding);
@@ -71,7 +75,18 @@ aside {
   box-shadow: var(--aside-shadow);
   transition: width 0.3s cubic-bezier(0.4,0,0.2,1), min-width 0.3s cubic-bezier(0.4,0,0.2,1), padding 0.3s cubic-bezier(0.4,0,0.2,1);
   min-width: var(--sidebar-width-collapsed);
-  position: relative;
+}
+
+#legend {
+  position: absolute;
+  bottom: 2rem;
+  left: 1rem;
+  z-index: 1000;
+  background: var(--aside-bg);
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--aside-border);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
 .aside-collapsed {


### PR DESCRIPTION
This change separates the settings menu and the legend into two distinct floating elements. The legend is now positioned on the left side of the screen, while the settings menu remains on the right. This improves the user interface by decluttering the main content area and providing a more intuitive layout.