### PR TITLE
Separate settings menu and legend

### DIFF
--- a/TTC/index.html
+++ b/TTC/index.html
@@ -42,32 +42,29 @@
       <div id="map"></div>
       <div id="legend">
         <h3>Legend</h3>
-        <div style="margin-bottom: 1rem;">
-          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-            <span
-              style="display:inline-block;width:24px;height:6px;background:#F8C300;opacity:0.4;margin-right:8px;"></span>
+        <div class="legend-content">
+          <div class="legend-item">
+            <span class="legend-line legend-line1-regular"></span>
             <span>Line 1 (Regular)</span>
           </div>
-          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-            <span style="display:inline-block;width:24px;height:6px;background:#F8C300;margin-right:8px;"></span>
+          <div class="legend-item">
+            <span class="legend-line legend-line1-rsz"></span>
             <span>Line 1 (Reduced Speed Zone)</span>
           </div>
-          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-            <span
-              style="display:inline-block;width:24px;height:6px;background:#00923F;opacity:0.4;margin-right:8px;"></span>
+          <div class="legend-item">
+            <span class="legend-line legend-line2-regular"></span>
             <span>Line 2 (Regular)</span>
           </div>
-          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-            <span style="display:inline-block;width:24px;height:6px;background:#00923F;margin-right:8px;"></span>
+          <div class="legend-item">
+            <span class="legend-line legend-line2-rsz"></span>
             <span>Line 2 (Reduced Speed Zone)</span>
           </div>
-          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-            <span
-              style="display:inline-block;width:24px;height:6px;background:#A21A68;opacity:0.4;margin-right:8px;"></span>
+          <div class="legend-item">
+            <span class="legend-line legend-line4-regular"></span>
             <span>Line 4 (Regular)</span>
           </div>
-          <div style="display: flex; align-items: center; margin-bottom: 0.3rem;">
-            <span style="display:inline-block;width:24px;height:6px;background:#A21A68;margin-right:8px;"></span>
+          <div class="legend-item">
+            <span class="legend-line legend-line4-rsz"></span>
             <span>Line 4 (Reduced Speed Zone)</span>
           </div>
         </div>

--- a/TTC/style.css
+++ b/TTC/style.css
@@ -28,6 +28,12 @@
   --zone-border: light-dark(#eee, #444);
   --zone-strong: #2c3e50;
   --zone-span: #7f8c8d;
+  
+  /* Z-index scale */
+  --z-map: 100;
+  --z-legend: 1000;
+  --z-sidebar: 1100;
+  --z-sidebar-toggle: 1200;
 }
 
 body,
@@ -56,9 +62,9 @@ header h1 {
 }
 
 main {
-  display: flex;
   flex: 1;
   overflow: hidden;
+  position: relative;
   container-type: inline-size;
 }
 
@@ -66,28 +72,64 @@ aside {
   position: absolute;
   top: 1rem;
   right: 1rem;
-  z-index: 1000;
+  z-index: var(--z-sidebar);
   width: var(--sidebar-width);
+  max-width: calc(100vw - 2rem);
   background-color: var(--aside-bg);
   padding: var(--sidebar-padding);
   overflow-y: auto;
-  border-right: 1px solid var(--aside-border);
+  border: 1px solid var(--aside-border);
+  border-radius: 8px;
   box-shadow: var(--aside-shadow);
   transition: width 0.3s cubic-bezier(0.4,0,0.2,1), min-width 0.3s cubic-bezier(0.4,0,0.2,1), padding 0.3s cubic-bezier(0.4,0,0.2,1);
   min-width: var(--sidebar-width-collapsed);
+  max-height: calc(100vh - 2rem);
 }
 
 #legend {
   position: absolute;
   bottom: 2rem;
   left: 1rem;
-  z-index: 1000;
+  z-index: var(--z-legend);
   background: var(--aside-bg);
   padding: 0.5rem 1rem;
   border: 1px solid var(--aside-border);
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  max-width: calc(100vw - 2rem);
 }
+
+#legend h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  color: var(--zone-strong);
+}
+
+.legend-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-line {
+  display: inline-block;
+  width: 24px;
+  height: 6px;
+  border-radius: 1px;
+}
+
+.legend-line1-regular { background: rgba(248,195,0,0.4); }
+.legend-line1-rsz { background: #F8C300; }
+.legend-line2-regular { background: rgba(0,146,63,0.4); }
+.legend-line2-rsz { background: #00923F; }
+.legend-line4-regular { background: rgba(162,26,104,0.4); }
+.legend-line4-rsz { background: #A21A68; }
 
 .aside-collapsed {
   width: 40px !important;
@@ -121,7 +163,7 @@ aside {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 10;
+  z-index: var(--z-sidebar-toggle);
   transition: background 0.2s;
 }
 .sidebar-toggle:hover,
@@ -178,13 +220,17 @@ aside h3 {
 }
 
 #map-container {
-  flex: 1;
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 #map {
   height: 100%;
   width: 100%;
+  z-index: var(--z-map);
 }
 
 footer {
@@ -227,7 +273,7 @@ footer a:focus-visible {
   justify-content: center;
   font-size: 1.5rem;
   cursor: pointer;
-  z-index: 1200;
+  z-index: var(--z-sidebar-toggle);
   transition: background 0.2s, box-shadow 0.2s;
   pointer-events: auto;
 }
@@ -238,28 +284,59 @@ footer a:focus-visible {
   box-shadow: 0 4px 12px rgba(0,0,0,0.18);
 }
 
-/* Responsive Design: fallback for browsers without container queries */
+/* Responsive Design */
 @media (max-width: 768px) {
-  main {
-    flex-direction: column;
-  }
   aside {
-    width: 100% !important;
+    top: 0.5rem;
+    right: 0.5rem;
+    left: 0.5rem;
+    width: auto;
+    max-width: none;
     max-height: 40vh;
-    border-right: none;
-    border-bottom: 1px solid var(--aside-border);
-    min-width: 0;
-    padding: var(--sidebar-padding) !important;
   }
-  .aside-collapsed {
-    width: 40px !important;
-    min-width: 40px !important;
-    padding: 0 !important;
+  
+  #legend {
+    bottom: 0.5rem;
+    left: 0.5rem;
+    right: 0.5rem;
+    max-width: none;
   }
+  
+  .legend-content {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  
+  .legend-item {
+    flex: 1;
+    min-width: fit-content;
+  }
+  
+  .legend-item span:last-child {
+    font-size: 0.8rem;
+  }
+  
   header h1 {
     font-size: 1.1rem;
   }
-  #map-container {
-    height: 60vh;
-  }
 }
+
+@media (max-width: 480px) {
+  .legend-content {
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  
+  .legend-item span:last-child {
+    font-size: 0.75rem;
+  }
+  
+  #legend {
+    padding: 0.4rem 0.8rem;
+  }
+  
+  aside {
+    padding: 0.8rem;
+  }
+}mo


### PR DESCRIPTION
This change separates the settings menu and the legend into two distinct floating elements. The legend is now positioned on the left side of the screen, while the settings menu remains on the right. This improves the user interface by decluttering the main content area and providing a more intuitive layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the sidebar and legend positioning for improved layout, placing the legend within the map area and styling it as a floating panel.
  * Enhanced the visual appearance of the legend with background color, padding, border, rounded corners, and a shadow effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->